### PR TITLE
Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ npm install
 
 ## Usage
 
+### Command line
+
 - Put ActivityStreams notifications in the `in` directory
 - Put N3 rules in the `rules` directory
 - Run `bin/orch --keep rules/*` to run the rules on alle in notification in the `in` directory
@@ -65,6 +67,35 @@ npm install
 - If you want to experiment with expressing N3 rules as [RDF Surfacs](https://josd.github.io/surface/) use the following commands:
     - run `npm run orch:blogic` : this will execute the [rules/blogic/00_demo.n3](rules/blogic/00_demo.n3) rule which is a direct translation of [rules/00_demo.n3](rules/00_demo.n3) in the RDF Surfaces language
     - run `npm run orch:policy` : this will read [rules/blogic/00_policy.n3](rules/blogic/00_policy.n3) (written in a small DSL language) and compile these rules into RDF Surfaces using a compiler available in [rules/blogic/policy](rules/blogic/policy) 
+
+### Typescript/javascript
+
+Small javascript example to execute Koreografeye using [`demo.ttl`](./data/demo.ttl) and [`00_demo.n3`](./rules/00_demo.n3).
+
+```javascript
+const { reason } = require('./dist/orchestrator/Reason');
+const { executePolicies } = require('./dist/policy/Executor');
+const { loadConfig, parseAsN3Store, readText, storeAddPredicate } = require('./dist/util');
+
+const store = await parseAsN3Store('./data/demo.ttl'); // input graph
+const rules = [readText('./rules/00_demo.n3')] // array of n3 rules serialized as string
+const orchestratorConfig = loadConfig('./orchestrator.json') // orchestrator config -> these are the eye arguments
+
+// add main subject and origin for the reasoner
+const mainSubject = 'urn:uuid:42D2F3DC-0770-4F47-BF37-4F01E0382E32'
+storeAddPredicate(store, 'https://www.example.org/ns/policy#mainSubject', mainSubject);
+storeAddPredicate(store, 'https://www.example.org/ns/policy#origin', './data/demo.ttl');
+
+// execute reasoning (orchestration)
+const reasoningResult = await reason(store, orchestratorConfig, rules);
+
+const plugins = loadConfig('./plugin.json') // configuration for the policy executor
+
+// execute policies
+await executePolicies(plugins, reasoningResult)
+```
+
+Note: for this code to run, the project has to be compiled first (`npm run build`).
 
 ## Commands
 

--- a/src/orch.ts
+++ b/src/orch.ts
@@ -4,6 +4,7 @@ import * as log4js from 'log4js';
 import { program } from 'commander';
 import { spawn} from 'node:child_process';
 import { parseAsN3Store, rdfTransformStore , topGraphIds , storeAddPredicate, loadConfig} from './util';
+import * as Reason from './orchestrator/Reason';
 
 const POL_MAIN_SUBJECT = 'https://www.example.org/ns/policy#mainSubject';
 const POL_ORIGIN       = 'https://www.example.org/ns/policy#origin';
@@ -67,12 +68,9 @@ async function reason(dataPath: string , rulePaths: string[]) {
             return reject(`failed to load ${orchConf}`);
         }
 
-        const eye = config['eye'];
-        const eyeargs = config['args'];
-
         logger.debug(`parsing ${dataPath}...`);
         const store = await parseAsN3Store(dataPath);
-
+        
         if (!store) {
             return reject(`failed to create a store from ${dataPath}`);
         }
@@ -89,49 +87,9 @@ async function reason(dataPath: string , rulePaths: string[]) {
         // Inject the file origin in the KG
         storeAddPredicate(store, POL_ORIGIN, dataPath);
 
-        const n3  = await rdfTransformStore(store, 'text/turtle');
-
-        if (!n3) {
-           return reject(`failed to transform store to turtle`);
-        }
-
-        logger.trace(n3);
-
-        const tmpobj = tmp.fileSync();
-
-        if (! tmpobj) {
-            return reject(`failed to create tmp object`);
-        }
-
-        logger.debug(`tmp file: ${tmpobj.name}`);
-
-        logger.debug(`writing n3 to ${tmpobj.name}`);
-        fs.writeFileSync(tmpobj.name, n3);
-
-        eyeargs.push(tmpobj.name);
-        rulePaths.filter(f => fs.lstatSync(f).isFile() ).forEach(r => eyeargs.push(r));
-
-        logger.info(`${eye}`);
-        logger.info(`eye args: ${eyeargs}`);
-
-        let errorData = '';
-        let resultData = '';
-
-        const ls = spawn(eye,eyeargs);
-        ls.stdout.on('data', (data) => {
-            resultData += data;
-        });
-        ls.stderr.on('data', (data) => {
-            errorData += data;
-        });
-        ls.on('close', (code) => {
-            tmpobj.removeCallback();
-            if (code != 0) {
-                return reject(errorData);
-            }
-            else {
-                return resolve(resultData);
-            }
-        });
+        const resultStore = await Reason.reason(store, config, rulePaths, logger);
+        
+        const result = await rdfTransformStore(resultStore, 'text/turtle');
+        return resolve(result);
     });
 }

--- a/src/orch.ts
+++ b/src/orch.ts
@@ -84,7 +84,7 @@ async function reason(dataPath: string , rulePaths: string[]) {
         // Inject the file origin in the KG
         storeAddPredicate(store, POL_ORIGIN, dataPath);
 
-        const resultStore = await Reason.reason(store, config, rulePaths, logger);
+        const resultStore = await Reason.reasonRulePaths(store, config, rulePaths, logger);
         
         const result = await rdfTransformStore(resultStore, 'text/turtle');
         return resolve(result);

--- a/src/orch.ts
+++ b/src/orch.ts
@@ -1,10 +1,7 @@
-import * as fs from 'fs';
-import * as tmp from 'tmp';
-import * as log4js from 'log4js';
 import { program } from 'commander';
-import { spawn} from 'node:child_process';
-import { parseAsN3Store, rdfTransformStore , topGraphIds , storeAddPredicate, loadConfig} from './util';
+import * as log4js from 'log4js';
 import * as Reason from './orchestrator/Reason';
+import { loadConfig, parseAsN3Store, rdfTransformStore, storeAddPredicate, topGraphIds } from './util';
 
 const POL_MAIN_SUBJECT = 'https://www.example.org/ns/policy#mainSubject';
 const POL_ORIGIN       = 'https://www.example.org/ns/policy#origin';

--- a/src/orchestrator/Reason.ts
+++ b/src/orchestrator/Reason.ts
@@ -1,14 +1,22 @@
 import { Logger } from "log4js";
 import { Store } from "n3";
 import * as fs from 'fs';
-import * as tmp from 'tmp';
+import { FileResult, fileSync } from "tmp";
 import { spawn } from 'node:child_process';
-
 import { parseStringAsN3Store, rdfTransformStore } from "../util";
 
-export async function reason(dataStore: Store, config: any, rulePaths: string[], logger: Logger): Promise<Store> {
+/**
+ * Reason over an input RDF graph with rules using the eye reasoner.
+ * 
+ * @param dataStore - N3 store containing the data.
+ * @param config - Orchestrator configuration (contains eye arguments).
+ * @param rulePaths - The paths to the files containing the N3 rules.
+ * @param logger - Logger.
+ * @returns N3 store containing the result of applying the rulest to the input dataStore.
+ */
+export async function reason(dataStore: Store, config: any, rulePaths: string[], logger: Logger): Promise<Store> { // TODO: call reason2
   const eye = config['eye'];
-  const eyeargs = config['args'];
+  const eyeargs = [...config['args']]; // deep copy wanted as we push items to eyeargs
 
   const n3 = await rdfTransformStore(dataStore, 'text/turtle');
 
@@ -18,16 +26,7 @@ export async function reason(dataStore: Store, config: any, rulePaths: string[],
 
   logger.trace(n3);
 
-  const tmpobj = tmp.fileSync();
-
-  if (!tmpobj) {
-    throw new Error(`failed to create tmp object`);
-  }
-
-  logger.debug(`tmp file: ${tmpobj.name}`);
-
-  logger.debug(`writing n3 to ${tmpobj.name}`);
-  fs.writeFileSync(tmpobj.name, n3);
+  const tmpobj = createTmpFile(n3, logger);
 
   eyeargs.push(tmpobj.name);
   rulePaths.filter(f => fs.lstatSync(f).isFile()).forEach(r => eyeargs.push(r));
@@ -42,7 +41,64 @@ export async function reason(dataStore: Store, config: any, rulePaths: string[],
   return resultStore
 }
 
-async function eyeRunner(eye: string, args: string[]): Promise<string> {
+/**
+ * Reason over an input RDF graph with rules using the eye reasoner.
+ * 
+ * @param dataStore - N3 store containing the data.
+ * @param config - Orchestrator configuration (contains eye arguments).
+ * @param rulePaths - An array of N3 stores containing the N3 rules.
+ * @param logger - Logger.
+ * @returns N3 store containing the result of applying the rulest to the input dataStore.
+ */
+export async function reasonUsingN3(dataStore: Store, config: any, rules: Store[], logger: Logger): Promise<Store> {
+  const eye = config['eye'];
+  const eyeargs = [...config['args']]; // deep copy wanted as we push items to eyeargs
+
+  // create file (text/plain) for data
+  const n3 = await rdfTransformStore(dataStore, 'text/turtle');
+
+  if (!n3) {
+    throw new Error(`failed to transform store to turtle`);
+  }
+
+  logger.trace(n3);
+
+  const tmpobj = createTmpFile(n3, logger);
+  eyeargs.push(tmpobj.name)
+
+  // create files (text/plain) for rules
+  const ruleObjects: FileResult[] = [];
+  rules.forEach(async store => {
+    // TODO: fix a real N3 rule serializer, it does not work yet :(
+    const ruleN3Text = await rdfTransformStore(store, 'text/n3')
+    
+    if (!ruleN3Text) {
+      throw new Error(`failed to transform store to turtle`);
+    }
+    const tmpRule = createTmpFile(ruleN3Text, logger)
+    ruleObjects.push(tmpRule)
+
+    eyeargs.push(tmpRule.name)
+  })
+
+  logger.info(`${eye}`);
+  logger.info(`eye args: ${eyeargs}`);
+
+  const result = await eyeRunner(eye, eyeargs)
+  tmpobj.removeCallback();
+  ruleObjects.forEach(tmp => tmp.removeCallback())
+  const resultStore = await parseStringAsN3Store(result)
+
+  return resultStore
+}
+
+/**
+ * Runs the eye reasoner.
+ * @param eye - command to start eye (often a path).
+ * @param args - arguments to run the eye reasoner.
+ * @returns {string} Result of the eye reasoner.
+ */
+export async function eyeRunner(eye: string, args: string[]): Promise<string> {
   return new Promise<string>(async (resolve, reject) => {
     let errorData = '';
     let resultData = '';
@@ -63,4 +119,24 @@ async function eyeRunner(eye: string, args: string[]): Promise<string> {
       }
     });
   })
+}
+
+/**
+ * Creates a temporary file. (execute `removeCallback()` on the {@link FileResult} return value)
+ * @param text - plain text to be put into a temporary file.
+ * @param logger - Logger.
+ * @returns {FileResult}
+ */
+export function createTmpFile(text: string, logger: Logger): FileResult {
+  const tmpobj = fileSync();
+
+  if (!tmpobj) {
+    throw new Error(`failed to create tmp object`);
+  }
+
+  logger.debug(`tmp file: ${tmpobj.name}`);
+
+  logger.debug(`writing n3 to ${tmpobj.name}`);
+  fs.writeFileSync(tmpobj.name, text);
+  return tmpobj
 }

--- a/src/orchestrator/Reason.ts
+++ b/src/orchestrator/Reason.ts
@@ -1,0 +1,66 @@
+import { Logger } from "log4js";
+import { Store } from "n3";
+import * as fs from 'fs';
+import * as tmp from 'tmp';
+import { spawn } from 'node:child_process';
+
+import { parseStringAsN3Store, rdfTransformStore } from "../util";
+
+export async function reason(dataStore: Store, config: any, rulePaths: string[], logger: Logger): Promise<Store> {
+  const eye = config['eye'];
+  const eyeargs = config['args'];
+
+  const n3 = await rdfTransformStore(dataStore, 'text/turtle');
+
+  if (!n3) {
+    throw new Error(`failed to transform store to turtle`);
+  }
+
+  logger.trace(n3);
+
+  const tmpobj = tmp.fileSync();
+
+  if (!tmpobj) {
+    throw new Error(`failed to create tmp object`);
+  }
+
+  logger.debug(`tmp file: ${tmpobj.name}`);
+
+  logger.debug(`writing n3 to ${tmpobj.name}`);
+  fs.writeFileSync(tmpobj.name, n3);
+
+  eyeargs.push(tmpobj.name);
+  rulePaths.filter(f => fs.lstatSync(f).isFile()).forEach(r => eyeargs.push(r));
+
+  logger.info(`${eye}`);
+  logger.info(`eye args: ${eyeargs}`);
+
+  const result = await eyeRunner(eye, eyeargs)
+  tmpobj.removeCallback();
+  const resultStore = await parseStringAsN3Store(result)
+
+  return resultStore
+}
+
+async function eyeRunner(eye: string, args: string[]): Promise<string> {
+  return new Promise<string>(async (resolve, reject) => {
+    let errorData = '';
+    let resultData = '';
+
+    const ls = spawn(eye, args);
+    ls.stdout.on('data', (data) => {
+      resultData += data;
+    });
+    ls.stderr.on('data', (data) => {
+      errorData += data;
+    });
+    ls.on('close', (code) => {
+      if (code != 0) {
+        return reject(errorData);
+      }
+      else {
+        return resolve(resultData);
+      }
+    });
+  })
+}

--- a/src/pol.ts
+++ b/src/pol.ts
@@ -1,13 +1,8 @@
-import * as N3 from 'n3';
-import { QueryEngine } from '@comunica/query-sparql-rdfjs';
-import { BlankNodeScoped } from '@comunica/data-factory';
-import { program  } from 'commander';
-import { loadConfig, storeGetPredicate, parseAsN3Store , extractGraph , type IPolicyType} from './util';
-import { DataFactory } from 'rdf-data-factory';
+import { program } from 'commander';
 import * as log4js from 'log4js';
+import { executePolicies } from './policy/Executor';
+import { loadConfig, parseAsN3Store, storeGetPredicate } from './util';
 
-const POL = 'https://www.example.org/ns/policy#';
-const FNO = 'https://w3id.org/function/ontology#';
 const POL_MAIN_SUBJECT = 'https://www.example.org/ns/policy#mainSubject';
 const POL_ORIGIN       = 'https://www.example.org/ns/policy#origin';
 let   pluginConf = './plugin.json';
@@ -40,7 +35,6 @@ if (opts.trace) {
     logger.level = "trace";
 }
 
-const myEngine = new QueryEngine();
 const data     = program.args[0];
 
 execute_policies(data);
@@ -77,58 +71,7 @@ async function execute_policies(path: string) {
         logger.debug(`origin: ${origin.value}`);
     }
     
-    const policies = await extractPolicies(store,path, {
-        mainSubject: mainSubject ,
-        origin: origin
-    });
-
-    const mainStore = extractGraph(store,mainSubject);
-
-    for (let key in policies) {
-        const policy = policies[key];
-        const idNode = policy['node'];
-        const target = policy['target'];
-        let   implementation;
-        let   implementationConfiguration : any = {};
-
-        if (plugins[target]) {
-            if (typeof plugins[target] === 'string') {
-                implementation = plugins[target];
-            }
-            else {
-                implementation = plugins[target]['@id'];
-                implementationConfiguration = plugins[target];
-            }
-        }
-       
-        const policyStore = extractGraph(store,idNode);
-
-        policy['mainSubject'] = mainSubject.value;
-        policy['origin'] = origin.value;
-        policy['config'] = implementationConfiguration;
-        
-        if (implementation) {
-            logger.info(`${target} -> ${implementation}`);
-
-            try {
-                const isOk = await callImplementation(implementation,mainStore,policyStore,policy);
-                if (isOk) {
-                    // All is well
-                }
-                else {
-                    errors += 1;
-                }
-            }
-            catch (e) {
-                console.error(`Target ${target} (${implementation}) threw error ${e}`);
-                errors += 1;
-            }
-        }
-        else {
-            logger.error(`${target} has no implementation`);
-            errors += 1;
-        }
-    }
+    errors = await executePolicies(plugins, store, logger);
 
     if (errors == 0) {
         process.exit(0);
@@ -136,102 +79,4 @@ async function execute_policies(path: string) {
     else {
         process.exit(2);
     }
-}
-
-async function callImplementation(plugin:string, mainStore: N3.Store, policyStore: N3.Store, policy:any) {
-    logger.info(`calling ${plugin}...`);
-    const pkg = await import(plugin);
-    const result = await pkg.policyTarget(mainStore, policyStore,policy);
-    logger.info(`..returned a ${result}`);
-    return result;
-}
-
-async function extractPolicies(store: N3.Store, path: string, xtra: any) {
-    const sql = `
-PREFIX pol: <${POL}> 
-PREFIX fno: <${FNO}>
-
-SELECT ?id ?policy ?executionTarget ?name ?value WHERE {
-    ?id pol:policy ?policy .
-    ?policy a fno:Execution .
-    ?policy fno:executes ?executionTarget .
-    OPTIONAL { ?policy ?name ?value . } .
-}
-`;
-    logger.trace(sql);
-    const bindingStream = await myEngine.queryBindings(sql, {
-        sources: [ store ] 
-    });
-
-    const bindings = await bindingStream.toArray();
-
-    const policies : { [id: string] : IPolicyType } = {};
-
-    const DF = new DataFactory();
-
-    bindings.forEach( (binding) => {
-        const id = binding.get('id')?.value ;
-
-        let idNode : N3.NamedNode | N3.BlankNode;
-
-        if (id) {
-            if (binding.get('id')?.termType == 'BlankNode') {
-                idNode = N3.DataFactory.blankNode(id);
-            }
-            else if (binding.get('id')?.termType == 'NamedNode') {
-                idNode = N3.DataFactory.namedNode(id);
-            }
-            else {
-                logger.error(`wrong termType for policy ${binding.get('id')?.termType}`);
-                return;
-            }
-        }
-        else {
-            logger.error(`no policy found`);
-            return;
-        }
-
-        const policy          = binding.get('policy')?.value.toString();
-        const executionTarget = binding.get('executionTarget')?.value.toString();
-        const name            = binding.get('name')?.value.toString() ?? '<undef>';
-        const value           = binding.get('value');
-
-        if (id && policy && executionTarget) {
-            logger.info(`found policy ${id} with target ${executionTarget}`);
-        }
-        else {
-            logger.error('failed to find pol:policy or a fno:Executes with fno:executes');
-            return;
-        }
-
-        if (policies[id]) {
-            if (value?.termType === 'BlankNode' && value instanceof BlankNodeScoped ) {
-                // Comunica makes skolemnized values out of blank nodes...
-                // We need the original blank node id so that N3.Store in other 
-                // part of our code can make use of that
-                const skolemizedName = (<BlankNodeScoped> value).skolemized.value;
-                const unSkolemizedName = skolemizedName.replace(/urn:comunica_skolem:source[^:]+:/,"");
-                policies[id]['args'][name] = DF.blankNode(unSkolemizedName);
-            } 
-            else {
-                policies[id]['args'][name] = value;
-            }
-        }
-        else {
-            policies[id] = {
-                'node'   : idNode ,
-                'path'   : path ,
-                'policy' : policy ,
-                'target' : executionTarget,
-                'args'   : {} ,
-                ...xtra
-            };
-            policies[id]['args'][name] = value;
-        }
-    });
-
-    logger.debug(`policies:`);
-    logger.debug(policies);
-
-    return policies;
 }

--- a/src/policy/Executor.ts
+++ b/src/policy/Executor.ts
@@ -1,0 +1,89 @@
+import { Logger } from 'log4js';
+import * as N3 from 'n3';
+import { extractGraph, storeGetPredicate } from '../util';
+import { extractPolicies, findPlugin, refinePolicy } from './Extractor';
+
+async function callImplementation(plugin: string, mainStore: N3.Store, policyStore: N3.Store, policy: any, logger: Logger) {
+  logger.info(`calling ${plugin}...`);
+  const pkg = await import('.'+plugin); // NOTE: ugly hack, MUST be removed
+  const result = await pkg.policyTarget(mainStore, policyStore, policy);
+  logger.info(`..returned a ${result}`);
+  return result;
+}
+
+export async function executePolicies(plugins: any, reasoningResultStore: N3.Store, logger: Logger): Promise<number> {
+  const mainSubject = fetchMainSubject(reasoningResultStore, logger);
+  const origin = fetchOrigin(reasoningResultStore, logger);
+  const policies = await extractPolicies(reasoningResultStore, "none", {}, logger);
+
+  let errors = 0
+  // refine policies
+  for (const policy of Object.values(policies)) {
+    // Add mainSubject, origin and config to the policy 
+    refinePolicy(plugins, policy, mainSubject.value, origin.value);
+  }
+
+  // execute policies
+  for (const policy of Object.values(policies)) {
+    const idNode = policy['node'];
+    const target = policy['target'];
+
+    const { implementation } = findPlugin(plugins, target)
+
+    const policyStore = extractGraph(reasoningResultStore, idNode);
+    const mainStore = extractGraph(reasoningResultStore, mainSubject);
+
+    if (implementation) {
+      logger.info(`${target} -> ${implementation}`);
+
+      try {
+        const isOk = await callImplementation(implementation, mainStore, policyStore, policy, logger);
+        if (isOk) {
+          // All is well
+        }
+        else {
+          errors += 1;
+        }
+      }
+      catch (e) {
+        console.error(`Target ${target} (${implementation}) threw error ${e}`);
+        errors += 1;
+      }
+    }
+    else {
+      logger.error(`${target} has no implementation`);
+      errors += 1;
+    }
+  }
+  return errors
+}
+
+function fetchMainSubject(store: N3.Store, logger: Logger) {
+  const POL_MAIN_SUBJECT = 'https://www.example.org/ns/policy#mainSubject';
+
+  const mainSubject = storeGetPredicate(store, POL_MAIN_SUBJECT);
+
+  if (!mainSubject) {
+    console.error(`no ${POL_MAIN_SUBJECT}?!`);
+    logger.error(`no ${POL_MAIN_SUBJECT}?!`);
+    process.exit(2);
+  }
+  else {
+    logger.debug(`main subject: ${mainSubject.value}`);
+  }
+  return mainSubject
+}
+
+function fetchOrigin(store: N3.Store, logger: Logger) {
+  const POL_ORIGIN = 'https://www.example.org/ns/policy#origin';
+  const origin = storeGetPredicate(store, POL_ORIGIN);
+
+  if (!origin) {
+    logger.error(`no ${POL_ORIGIN}?!`);
+    process.exit(2);
+  }
+  else {
+    logger.debug(`origin: ${origin.value}`);
+  }
+  return origin;
+}

--- a/src/policy/Executor.ts
+++ b/src/policy/Executor.ts
@@ -3,14 +3,33 @@ import * as N3 from 'n3';
 import { extractGraph, storeGetPredicate } from '../util';
 import { extractPolicies, findPlugin, refinePolicy } from './Extractor';
 
+/**
+ * Executes a single policy and returns the result.
+ * 
+ * @param plugin - Object that contains the configuration for the plugins.
+ * @param mainStore - N3 Store containing the input RDF graph.
+ * @param policyStore - N3 Store containing the policy to be executed.
+ * @param policy - policy configuration
+ * @param logger - Logger.
+ * @returns the result of the policy when it was correctly executed.
+ */
 async function callImplementation(plugin: string, mainStore: N3.Store, policyStore: N3.Store, policy: any, logger: Logger) {
   logger.info(`calling ${plugin}...`);
-  const pkg = await import('.'+plugin); // NOTE: ugly hack, MUST be removed
+  const pkg = await import('.' + plugin); // NOTE: ugly hack, MUST be removed
   const result = await pkg.policyTarget(mainStore, policyStore, policy);
   logger.info(`..returned a ${result}`);
   return result;
 }
 
+/**
+ * Extracts policies out of the graph.
+ * When they are extracted, the plugins are fetched and executed.
+ * 
+ * @param plugins - Object that contains the configuration for the plugins.
+ * @param reasoningResultStore - N3 Store that contains the result of the reasoner (data + ?policies).
+ * @param logger - Logger.
+ * @returns {Promise<number>} Number of errors.
+ */
 export async function executePolicies(plugins: any, reasoningResultStore: N3.Store, logger: Logger): Promise<number> {
   const mainSubject = fetchMainSubject(reasoningResultStore, logger);
   const origin = fetchOrigin(reasoningResultStore, logger);
@@ -58,6 +77,13 @@ export async function executePolicies(plugins: any, reasoningResultStore: N3.Sto
   return errors
 }
 
+/**
+ * Retrieve the main Policy Subject from the input data graph.
+ * 
+ * @param store - N3 Store data store.
+ * @param logger - Logger.
+ * @returns The main subject for the policy.
+ */
 function fetchMainSubject(store: N3.Store, logger: Logger) {
   const POL_MAIN_SUBJECT = 'https://www.example.org/ns/policy#mainSubject';
 
@@ -74,6 +100,13 @@ function fetchMainSubject(store: N3.Store, logger: Logger) {
   return mainSubject
 }
 
+/**
+ * Retrieve the origin input file from the input data graph.
+ * 
+ * @param store - N3 Store data store.
+ * @param logger - Logger.
+ * @returns The origin for the policy.
+ */
 function fetchOrigin(store: N3.Store, logger: Logger) {
   const POL_ORIGIN = 'https://www.example.org/ns/policy#origin';
   const origin = storeGetPredicate(store, POL_ORIGIN);

--- a/src/policy/Executor.ts
+++ b/src/policy/Executor.ts
@@ -1,4 +1,4 @@
-import { Logger } from 'log4js';
+import { getLogger, Logger } from 'log4js';
 import * as N3 from 'n3';
 import { extractGraph, storeGetPredicate } from '../util';
 import { extractPolicies, findPlugin, refinePolicy } from './Extractor';
@@ -30,7 +30,9 @@ async function callImplementation(plugin: string, mainStore: N3.Store, policySto
  * @param logger - Logger.
  * @returns {Promise<number>} Number of errors.
  */
-export async function executePolicies(plugins: any, reasoningResultStore: N3.Store, logger: Logger): Promise<number> {
+export async function executePolicies(plugins: any, reasoningResultStore: N3.Store, logger?: Logger): Promise<number> {
+  logger = logger ?? getLogger();
+
   const mainSubject = fetchMainSubject(reasoningResultStore, logger);
   const origin = fetchOrigin(reasoningResultStore, logger);
   const policies = await extractPolicies(reasoningResultStore, "none", {}, logger);

--- a/src/policy/Extractor.ts
+++ b/src/policy/Extractor.ts
@@ -15,8 +15,8 @@ const myEngine = new QueryEngine();
  * `implementation` contains the plugin path
  * `implementationConfiguration` contains extra parameters
  * 
- * @param plugins 
- * @param target 
+ * @param plugins - Object that contains the configuration for the plugins.
+ * @param target - FnO identifier
  * @returns an object containing `implementation` and `implementationConfiguration`
  */
 export function findPlugin(plugins: any, target: string): any {
@@ -36,14 +36,14 @@ export function findPlugin(plugins: any, target: string): any {
 }
 
 /**
- * Extract policy from a graph
+ * Extract policies from a graph.
  * 
  * Note that the output does not conform yet to {@link IPolicyType}
- * @param store 
- * @param path 
- * @param xtra 
- * @param logger 
- * @returns 
+ * @param store - N3 Store containing policies.
+ * @param path - Input file (only used to fill in IPolicyType).
+ * @param xtra - extra arguments which are filled in {@link IPolicyType}.
+ * @param logger - Logger.
+ * @returns All policies from the graph as an Object of {@link IPolicyType}s.
  */
 export async function extractPolicies(store: N3.Store, path: string, xtra: any, logger: Logger): Promise<{ [id: string]: IPolicyType }> {
   const sql = `

--- a/src/policy/Extractor.ts
+++ b/src/policy/Extractor.ts
@@ -1,0 +1,148 @@
+import { BlankNodeScoped } from '@comunica/data-factory';
+import { QueryEngine } from '@comunica/query-sparql-rdfjs';
+import { Logger } from 'log4js';
+import * as N3 from 'n3';
+import { DataFactory } from 'rdf-data-factory';
+import { type IPolicyType } from '../util';
+
+const POL = 'https://www.example.org/ns/policy#';
+const FNO = 'https://w3id.org/function/ontology#';
+
+const myEngine = new QueryEngine();
+
+/**
+ * Extracts the plugin path and its possible extra parameters, given an object of plugins.
+ * `implementation` contains the plugin path
+ * `implementationConfiguration` contains extra parameters
+ * 
+ * @param plugins 
+ * @param target 
+ * @returns an object containing `implementation` and `implementationConfiguration`
+ */
+export function findPlugin(plugins: any, target: string): any {
+  let implementation;
+  let implementationConfiguration: any = {};
+
+  if (plugins[target]) {
+    if (typeof plugins[target] === 'string') {
+      implementation = plugins[target];
+    }
+    else {
+      implementation = plugins[target]['@id'];
+      implementationConfiguration = plugins[target];
+    }
+  }
+  return { implementation, implementationConfiguration }
+}
+
+/**
+ * Extract policy from a graph
+ * 
+ * Note that the output does not conform yet to {@link IPolicyType}
+ * @param store 
+ * @param path 
+ * @param xtra 
+ * @param logger 
+ * @returns 
+ */
+export async function extractPolicies(store: N3.Store, path: string, xtra: any, logger: Logger): Promise<{ [id: string]: IPolicyType }> {
+  const sql = `
+PREFIX pol: <${POL}> 
+PREFIX fno: <${FNO}>
+
+SELECT ?id ?policy ?executionTarget ?name ?value WHERE {
+  ?id pol:policy ?policy .
+  ?policy a fno:Execution .
+  ?policy fno:executes ?executionTarget .
+  OPTIONAL { ?policy ?name ?value . } .
+}
+`;
+  logger.trace(sql);
+  const bindingStream = await myEngine.queryBindings(sql, {
+    sources: [store]
+  });
+
+  const bindings = await bindingStream.toArray();
+
+  const policies: { [id: string]: IPolicyType } = {};
+
+  const DF = new DataFactory();
+
+  bindings.forEach((binding) => {
+    const id = binding.get('id')?.value;
+
+    let idNode: N3.NamedNode | N3.BlankNode;
+
+    if (id) {
+      if (binding.get('id')?.termType == 'BlankNode') {
+        idNode = N3.DataFactory.blankNode(id);
+      }
+      else if (binding.get('id')?.termType == 'NamedNode') {
+        idNode = N3.DataFactory.namedNode(id);
+      }
+      else {
+        logger.error(`wrong termType for policy ${binding.get('id')?.termType}`);
+        return;
+      }
+    }
+    else {
+      logger.error(`no policy found`);
+      return;
+    }
+
+    const policy = binding.get('policy')?.value.toString();
+    const executionTarget = binding.get('executionTarget')?.value.toString();
+    const name = binding.get('name')?.value.toString() ?? '<undef>';
+    const value = binding.get('value');
+
+    if (id && policy && executionTarget) {
+      logger.info(`found policy ${id} with target ${executionTarget}`);
+    }
+    else {
+      logger.error('failed to find pol:policy or a fno:Executes with fno:executes');
+      return;
+    }
+
+    if (policies[id]) {
+      if (value?.termType === 'BlankNode' && value instanceof BlankNodeScoped) {
+        // Comunica makes skolemnized values out of blank nodes...
+        // We need the original blank node id so that N3.Store in other 
+        // part of our code can make use of that
+        const skolemizedName = (<BlankNodeScoped>value).skolemized.value;
+        const unSkolemizedName = skolemizedName.replace(/urn:comunica_skolem:source[^:]+:/, "");
+        policies[id]['args'][name] = DF.blankNode(unSkolemizedName);
+      }
+      else {
+        policies[id]['args'][name] = value;
+      }
+    }
+    else {
+      policies[id] = {
+        'node': idNode,
+        'path': path,
+        'policy': policy,
+        'target': executionTarget,
+        'args': {},
+        ...xtra
+      };
+      policies[id]['args'][name] = value;
+    }
+  });
+
+  logger.debug(`policies:`);
+  logger.debug(policies);
+
+  return policies;
+}
+
+/**
+ * Add main subject, origin and config to a policy as this is not done in {@link extractPolicies}
+ */
+export function refinePolicy(plugins: any, policy: IPolicyType, mainSubject: string, origin: string): void {
+  const target = policy['target'];
+
+  const { implementationConfiguration } = findPlugin(plugins, target)
+  policy['mainSubject'] = mainSubject;
+  policy['origin'] = origin;
+  policy['config'] = implementationConfiguration;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -45,25 +45,36 @@ export function loadConfig(path:string): any | undefined {
  * @returns The parsed N3.Store
  */
 export async function parseAsN3Store(path: string) : Promise<N3.Store> {
-    const parser       = new N3.Parser();
-    const store        = new N3.Store();
-
     const rdfData = '' + fs.readFileSync(path, {encoding:'utf8', flag:'r'});
 
     const n3Data = await rdfTransformString(rdfData, path, 'text/n3');
 
-    return new Promise<N3.Store>( (resolve,reject) => {
-        parser.parse(n3Data, (error, quad, _) => {
-            if (error) {
-                reject(error);
-            }
-            else if (quad) {
-                store.addQuad(quad);
-            }
-            else {
-                resolve(store);
-            }
-        });
+    const store = await parseStringAsN3Store(n3Data);
+    return store;
+}
+
+/**
+ * Parse an RDF string and return the parsed N3.Store
+ * 
+ * @param n3Data - the RDF data as string
+ * @returns The parsed N3.Store
+ */
+export async function parseStringAsN3Store(n3Data: string): Promise<N3.Store> {
+    const parser       = new N3.Parser();
+    const store        = new N3.Store();
+  
+    return new Promise<N3.Store>((resolve, reject) => {
+      parser.parse(n3Data, (error, quad, _) => {
+        if (error) {
+          reject(error);
+        }
+        else if (quad) {
+          store.addQuad(quad);
+        }
+        else {
+          resolve(store);
+        }
+      });
     });
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -27,7 +27,7 @@ export type IPolicyType = {
 /**
  * Load a JSON configuration file and returns the parsed content or undefined on error.
  * 
- * @params path - the location off the configuration file
+ * @param path - the location off the configuration file
  * @returns JSON object | undefined
  */
 export function loadConfig(path:string): any | undefined {
@@ -38,6 +38,19 @@ export function loadConfig(path:string): any | undefined {
     return JSON.parse(cfg);
 }
 
+/**
+ * Load a text file and return it as a string.
+ * If the file does not exist, return undefined.
+ * 
+ * @param path - the location of a text file.
+ * @returns a string representing the input file.
+ */
+export function readText(path: string): string | undefined {
+    if (! fs.existsSync(path)) {
+        return undefined;
+    }
+    return '' + fs.readFileSync(path, {encoding:'utf8', flag:'r'})
+}
 /**
  * Parse an input file and return the parsed N3.Store
  * 
@@ -53,6 +66,12 @@ export async function parseAsN3Store(path: string) : Promise<N3.Store> {
     return store;
 }
 
+/**
+ * Parses an N3 input file and returns it as a parsed N3 Store.
+ * 
+ * @param path - the location of an N3 rules input file
+ * @returns The parsed N3 Store
+ */
 export async function parseRulesAsN3Store(path: string) : Promise<N3.Store> {
     const rdfData = '' + fs.readFileSync(path, {encoding:'utf8', flag:'r'});
     const store = await parseStringAsN3Store(rdfData, {format:'text/n3'});
@@ -114,7 +133,12 @@ export async function rdfTransformStore(store: N3.Store, outType: string): Promi
     );
     return await stringifyStream(outStream);
 }
-
+/**
+ * Stub: currently does not serialize N3 properly
+ * 
+ * @param store - an N3 Store.
+ * @returns The serialized N3.
+ */
 export async function n3TransformStore(store: N3.Store): Promise<string> {
     const outStream = rdfSerializer.serialize(
         store.match(), { contentType: 'text/n3' } 

--- a/src/util.ts
+++ b/src/util.ts
@@ -48,19 +48,24 @@ export async function parseAsN3Store(path: string) : Promise<N3.Store> {
     const rdfData = '' + fs.readFileSync(path, {encoding:'utf8', flag:'r'});
 
     const n3Data = await rdfTransformString(rdfData, path, 'text/n3');
-
+    
     const store = await parseStringAsN3Store(n3Data);
     return store;
 }
 
+export async function parseRulesAsN3Store(path: string) : Promise<N3.Store> {
+    const rdfData = '' + fs.readFileSync(path, {encoding:'utf8', flag:'r'});
+    const store = await parseStringAsN3Store(rdfData, {format:'text/n3'});
+    return store;
+}
 /**
  * Parse an RDF string and return the parsed N3.Store
  * 
  * @param n3Data - the RDF data as string
  * @returns The parsed N3.Store
  */
-export async function parseStringAsN3Store(n3Data: string): Promise<N3.Store> {
-    const parser       = new N3.Parser();
+export async function parseStringAsN3Store(n3Data: string, options:any ={}): Promise<N3.Store> {
+    const parser       = new N3.Parser(options);
     const store        = new N3.Store();
   
     return new Promise<N3.Store>((resolve, reject) => {
@@ -101,10 +106,21 @@ export async function rdfTransformString(data: string, fileName: string, outType
  * @returns The serialized RDF
  */
 export async function rdfTransformStore(store: N3.Store, outType: string): Promise<string> {
+    if (outType === 'text/n3') {
+        return n3TransformStore(store);
+    }
     const outStream = rdfSerializer.serialize(
                 store.match(undefined,undefined,undefined,undefined), { contentType: outType } 
     );
     return await stringifyStream(outStream);
+}
+
+export async function n3TransformStore(store: N3.Store): Promise<string> {
+    const outStream = rdfSerializer.serialize(
+        store.match(), { contentType: 'text/n3' } 
+    );
+return await stringifyStream(outStream);    
+
 }
 
 /**


### PR DESCRIPTION
This refactor makes it possible to run **Koreografeye** fully in JavaScript/TypeScript.

Both `pol.ts` and `orch.ts` now call functions `executePolicies(...)` and `reason(...)` respectively while keeping their original functionality.

In the `README.md` a section has been written how to execute the **Koreografeye** flow using javascript code.