### PR TITLE
feat: bump eyereasoner to 5.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
   "lsd:module": true,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "keywords": [ 
-    "choreography", 
-    "orchestration", 
-    "solid", 
-    "reasoning", 
+  "keywords": [
+    "choreography",
+    "orchestration",
+    "solid",
+    "reasoning",
     "solid-agent",
     "notation3"
   ],
@@ -44,7 +44,7 @@
     "@comunica/query-sparql-rdfjs": "^2.5.1",
     "commander": "^9.4.1",
     "componentsjs": "^5.3.2",
-    "eyereasoner": "4.25.2",
+    "eyereasoner": "5.0.6",
     "is-hidden-file": "^1.1.2",
     "jsonld": "^8.1.0",
     "log4js": "^6.7.0",


### PR DESCRIPTION
This makes sure that log:uuid built in works, as discussed in [this issue](https://github.com/eyereasoner/eye-js/issues/290)

I've locally tested the demo example run after installing v5.0.6 and building (`npm run build`) and this still works

The version of koreografeye in the package was not bumped, so a new release requires updating that first.