### PR TITLE
Fix: move @types/jsonld to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@comunica/context-entries": "^2.8.2",
     "@comunica/query-sparql-rdfjs": "^2.5.1",
+    "@types/jsonld": "^1.5.8",
     "commander": "^12.0.0",
     "componentsjs": "^5.3.2",
     "eyereasoner": "12.4.1",
@@ -70,7 +71,6 @@
     "@types/chai": "^4.3.5",
     "@types/fs-extra": "^11.0.1",
     "@types/glob": "^8.1.0",
-    "@types/jsonld": "^1.5.8",
     "@types/mocha": "^10.0.1",
     "@types/n3": "^1.10.4",
     "@types/streamify-string": "^1.0.0",


### PR DESCRIPTION
Koreografeye exports a reference to `NodeObject` of the `jsonld` package as return type of the `jsonldStrFrame` function in `src/util.ts` ([link](https://github.com/eyereasoner/Koreografeye/blob/d5c23bc7eb073229c9eb5915a60cfed0bab79fd9/src/util.ts#L151)). `@types/jsonld` should therefore be a dependency, not merely a development dependency.