### PR TITLE
chore: add `prepare` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "orch:benchmark": "node dist/orch.js --info --single data/demo.ttl --keep --out out rules/benchmark/00_benchmark.n3",
     "pol": "node dist/pol.js --info --keep --in out",
     "watch": "tsc --watch",
+    "prepare": "npm run build",
     "build": "npm run build:ts && npm run build:components",
     "build:ts": "tsc ; chmod 755 dist/*js",
     "build:components": "componentsjs-generator -s dist",


### PR DESCRIPTION
This adds a `prepare` script.

The reason for doing so is to allow for one to `npm i` the github repository and have the build step be performed as part of that.